### PR TITLE
Fix final code readability issues for perfect Credo compliance

### DIFF
--- a/lib/ash_reports/chart_engine.ex
+++ b/lib/ash_reports/chart_engine.ex
@@ -87,7 +87,7 @@ defmodule AshReports.ChartEngine do
 
   alias AshReports.ChartEngine.{ChartConfig, ChartData, ChartProvider}
   alias AshReports.ChartEngine.Providers.{ChartJsProvider, D3Provider, PlotlyProvider}
-  alias AshReports.{RenderContext, Cldr}
+  alias AshReports.{Cldr, RenderContext}
 
   @type chart_type :: :line | :bar | :pie | :area | :scatter | :histogram | :boxplot | :heatmap
   @type provider :: :chartjs | :d3 | :plotly

--- a/lib/ash_reports/interactive_engine.ex
+++ b/lib/ash_reports/interactive_engine.ex
@@ -45,7 +45,7 @@ defmodule AshReports.InteractiveEngine do
 
   """
 
-  alias AshReports.{RenderContext, Cldr}
+  alias AshReports.{Cldr, RenderContext}
   alias AshReports.InteractiveEngine.{FilterProcessor, PivotProcessor, StatisticalAnalyzer}
 
   @type filter_criteria :: map()

--- a/lib/ash_reports/interactive_engine/filter_processor.ex
+++ b/lib/ash_reports/interactive_engine/filter_processor.ex
@@ -161,7 +161,7 @@ defmodule AshReports.InteractiveEngine.FilterProcessor do
       :not_equals ->
         field_value != value
 
-      # Comparison operations  
+      # Comparison operations
       op when op in [:greater_than, :less_than, :greater_equal, :less_equal] ->
         compare_values(field_value, value, operation, context)
 
@@ -301,7 +301,7 @@ defmodule AshReports.InteractiveEngine.FilterProcessor do
         |> String.replace(~r/[ؤئ]/, "و")
 
       "he" ->
-        # Hebrew text normalization  
+        # Hebrew text normalization
         term
         |> String.downcase()
         # Final kaf to regular kaf


### PR DESCRIPTION
Fix all remaining code readability issues to achieve zero Credo warnings:

## Trailing Whitespace Fixes:
- Remove trailing space after "Comparison operations" comment in filter_processor.ex:164
- Remove trailing space after "Hebrew text normalization" comment in filter_processor.ex:304

## Alias Ordering Fixes:
- Fix alphabetical ordering in interactive_engine.ex: {RenderContext, Cldr} → {Cldr, RenderContext}
- Fix alphabetical ordering in chart_engine.ex: {RenderContext, Cldr} → {Cldr, RenderContext}

## Results:
- Credo status: "found no issues" - perfect compliance
- All 4 code readability issues resolved
- Consistent code style across all Phase 5.1 modules
- Professional code quality standards met

Phase 5.1 codebase now has zero Credo issues and represents enterprise-grade Elixir code quality with perfect style compliance.