### PR TITLE
Add MIT license and fix documentation references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AshReports Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/guides/user/advanced-features.md
+++ b/guides/user/advanced-features.md
@@ -2,7 +2,7 @@
 
 This guide covers the currently available advanced features in AshReports, including basic internationalization support and formatting capabilities.
 
-> **Important**: Many advanced features like comprehensive i18n, security DSL, caching, monitoring, and custom extensions are planned but not yet implemented. See [ROADMAP.md](../../ROADMAP.md) for the complete roadmap of planned features.
+> **Important**: Many advanced features like comprehensive i18n, security DSL, caching, monitoring, and custom extensions are planned but not yet implemented. See [ROADMAP.md](ROADMAP.md) for the complete roadmap of planned features.
 
 ## Table of Contents
 
@@ -77,7 +77,7 @@ end
 
 ### Planned i18n Features
 
-> **Note**: Comprehensive i18n features are planned for Phase 3. See [ROADMAP.md Phase 3](../../ROADMAP.md#phase-3-advanced-internationalization).
+> **Note**: Comprehensive i18n features are planned for Phase 3. See [ROADMAP.md Phase 3](ROADMAP.md#phase-3-advanced-internationalization).
 
 Planned features include:
 - ❌ Per-element locale specification
@@ -216,7 +216,7 @@ end
 
 ### Conditional Formatting (Basic)
 
-> **Note**: Advanced conditional formatting with expressions is planned. See [ROADMAP.md Phase 7](../../ROADMAP.md#phase-7-advanced-formatting). Current implementation supports basic keyword list conditions.
+> **Note**: Advanced conditional formatting with expressions is planned. See [ROADMAP.md Phase 7](ROADMAP.md#phase-7-advanced-formatting). Current implementation supports basic keyword list conditions.
 
 ```elixir
 format_spec :status_formatting do
@@ -595,7 +595,7 @@ end
 
 ## Planned Advanced Features
 
-The following advanced features are planned but not yet implemented. See [ROADMAP.md](../../ROADMAP.md) for complete details and timelines.
+The following advanced features are planned but not yet implemented. See [ROADMAP.md](ROADMAP.md) for complete details and timelines.
 
 ### Phase 3: Advanced Internationalization
 - Dynamic locale switching per element
@@ -797,14 +797,14 @@ end
 
 ## See Also
 
-- [ROADMAP.md](../../ROADMAP.md) - Complete feature roadmap
+- [ROADMAP.md](ROADMAP.md) - Complete feature roadmap
 - [Report Creation Guide](report-creation.md) - Building reports
 - [Integration Guide](integration.md) - Phoenix and LiveView integration
-- [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) - Current status
+- [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) - Current status
 
 ## Next Steps
 
-1. Review [ROADMAP.md](../../ROADMAP.md) to see planned advanced features
-2. Check [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) for current implementation status
+1. Review [ROADMAP.md](ROADMAP.md) to see planned advanced features
+2. Check [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) for current implementation status
 3. Build reports using currently available features
 4. Watch for updates as advanced features are implemented

--- a/guides/user/getting-started.md
+++ b/guides/user/getting-started.md
@@ -2,7 +2,7 @@
 
 AshReports is a comprehensive reporting extension for the Ash Framework that provides declarative report definitions with hierarchical band structures, multiple output formats, and internationalization support.
 
-> **Note**: This guide reflects the current implementation. For planned features, see [ROADMAP.md](../../ROADMAP.md).
+> **Note**: This guide reflects the current implementation. For planned features, see [ROADMAP.md](ROADMAP.md).
 
 ## Table of Contents
 
@@ -295,7 +295,7 @@ expression :full_name do
 end
 ```
 
-> **Note**: Full Ash expression support in expressions is a work in progress. See [ROADMAP.md Phase 4](../../ROADMAP.md#phase-4-performance-and-optimization).
+> **Note**: Full Ash expression support in expressions is a work in progress. See [ROADMAP.md Phase 4](ROADMAP.md#phase-4-performance-and-optimization).
 
 ### Aggregate Elements
 Statistical calculations within bands:
@@ -407,7 +407,7 @@ Structured data for API consumption:
 )
 ```
 
-> **Note**: Renderer implementations are currently in testing phase. See [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) for current status.
+> **Note**: Renderer implementations are currently in testing phase. See [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) for current status.
 
 ## Next Steps
 
@@ -468,4 +468,4 @@ AshReports is under active development. Core DSL and band system are production-
 - ⚠️ Full data loading pipeline (in progress)
 - 🔵 Advanced chart engine (planned)
 
-See [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) for complete details and [ROADMAP.md](../../ROADMAP.md) for planned features.
+See [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) for complete details and [ROADMAP.md](ROADMAP.md) for planned features.

--- a/guides/user/integration.md
+++ b/guides/user/integration.md
@@ -2,7 +2,7 @@
 
 This guide covers integrating AshReports with Phoenix, LiveView, and basic deployment scenarios.
 
-> **Note**: This guide reflects current basic integration capabilities. For planned features like scheduled reports, webhook notifications, and advanced LiveView features, see [ROADMAP.md Phase 9](../../ROADMAP.md#phase-9-integration-enhancements).
+> **Note**: This guide reflects current basic integration capabilities. For planned features like scheduled reports, webhook notifications, and advanced LiveView features, see [ROADMAP.md Phase 9](ROADMAP.md#phase-9-integration-enhancements).
 
 ## Table of Contents
 
@@ -249,7 +249,7 @@ Create a form for users to input report parameters:
 
 ### Basic LiveView Report Viewer
 
-> **Note**: Full LiveView integration with real-time updates and interactive features is planned. See [ROADMAP.md Phase 9](../../ROADMAP.md#phase-9-integration-enhancements). Current implementation provides basic rendering.
+> **Note**: Full LiveView integration with real-time updates and interactive features is planned. See [ROADMAP.md Phase 9](ROADMAP.md#phase-9-integration-enhancements). Current implementation provides basic rendering.
 
 ```elixir
 defmodule MyAppWeb.ReportLive.Show do
@@ -685,7 +685,7 @@ defmodule MyApp.Reports.Telemetry do
 end
 ```
 
-> **Note**: Telemetry integration is basic. Advanced monitoring and performance tracking are planned - see [ROADMAP.md Phase 6](../../ROADMAP.md#phase-6-monitoring-and-telemetry).
+> **Note**: Telemetry integration is basic. Advanced monitoring and performance tracking are planned - see [ROADMAP.md Phase 6](ROADMAP.md#phase-6-monitoring-and-telemetry).
 
 ## Troubleshooting
 
@@ -736,18 +736,18 @@ The following features are planned for future releases:
 - S3/cloud storage
 - GraphQL API
 
-See [ROADMAP.md Phase 9](../../ROADMAP.md#phase-9-integration-enhancements) for complete details.
+See [ROADMAP.md Phase 9](ROADMAP.md#phase-9-integration-enhancements) for complete details.
 
 ## Next Steps
 
 1. Review [Report Creation Guide](report-creation.md) to build reports
 2. Check out [Advanced Features](advanced-features.md) for formatting options
-3. Read [ROADMAP.md](../../ROADMAP.md) for upcoming integration features
-4. See [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) for current status
+3. Read [ROADMAP.md](ROADMAP.md) for upcoming integration features
+4. See [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) for current status
 
 ## See Also
 
 - [Phoenix Framework](https://www.phoenixframework.org/)
 - [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/)
 - [Ash Authentication](https://hexdocs.pm/ash_authentication/)
-- [ROADMAP.md](../../ROADMAP.md) - Planned integration features
+- [ROADMAP.md](ROADMAP.md) - Planned integration features

--- a/guides/user/report-creation.md
+++ b/guides/user/report-creation.md
@@ -2,7 +2,7 @@
 
 This guide covers report creation techniques in AshReports, including parameters, grouping, variables, and formatting.
 
-> **Note**: This guide reflects the current implementation. For planned features like advanced conditional formatting and streaming configuration, see [ROADMAP.md](../../ROADMAP.md).
+> **Note**: This guide reflects the current implementation. For planned features like advanced conditional formatting and streaming configuration, see [ROADMAP.md](ROADMAP.md).
 
 ## Table of Contents
 
@@ -498,7 +498,7 @@ end
 
 ### Conditional Format Specifications (Basic)
 
-> **Note**: Advanced conditional formatting with expressions is planned. See [ROADMAP.md Phase 7](../../ROADMAP.md#phase-7-advanced-formatting). Current implementation supports basic keyword list conditions.
+> **Note**: Advanced conditional formatting with expressions is planned. See [ROADMAP.md Phase 7](ROADMAP.md#phase-7-advanced-formatting). Current implementation supports basic keyword list conditions.
 
 ```elixir
 format_spec :amount_formatting do
@@ -905,7 +905,7 @@ end
 2. **Use aggregates wisely**: Database aggregates are more efficient than variables for simple sums
 3. **Consider data volume**: For large datasets, ensure proper indexing on group and sort fields
 
-> **Note**: Advanced streaming configuration and performance monitoring features are planned. See [ROADMAP.md Phase 4](../../ROADMAP.md#phase-4-performance-and-optimization).
+> **Note**: Advanced streaming configuration and performance monitoring features are planned. See [ROADMAP.md Phase 4](ROADMAP.md#phase-4-performance-and-optimization).
 
 ### Maintainability
 
@@ -924,8 +924,8 @@ end
 
 ### See Also
 
-- [ROADMAP.md](../../ROADMAP.md) - Planned features and timeline
-- [IMPLEMENTATION_STATUS.md](../../IMPLEMENTATION_STATUS.md) - Current implementation status
+- [ROADMAP.md](ROADMAP.md) - Planned features and timeline
+- [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md) - Current implementation status
 - [Advanced Features Guide](advanced-features.md) - What's currently available in advanced features
 - [Graphs and Visualizations](graphs-and-visualizations.md) - Chart integration
 

--- a/lib/ash_reports/renderers/json_renderer/json_renderer.ex
+++ b/lib/ash_reports/renderers/json_renderer/json_renderer.ex
@@ -138,7 +138,6 @@ defmodule AshReports.JsonRenderer do
   - Internal metadata fields (like `_index`)
   - Formatted values (only raw data)
   - Report structure information (bands, elements, etc.)
-  ```
 
   ## API Integration Features
 

--- a/mix.exs
+++ b/mix.exs
@@ -122,6 +122,10 @@ defmodule AshReports.MixProject do
       canonical: "http://hexdocs.pm/ash_reports",
       extras: [
         "README.md",
+        "ROADMAP.md": [title: "Roadmap"],
+        "SECURITY.md": [title: "Security"],
+        "IMPLEMENTATION_STATUS.md": [title: "Implementation Status"],
+        "LICENSE": [title: "License"],
         # User Guides
         "guides/user/getting-started.md": [title: "Getting Started"],
         "guides/user/report-creation.md": [title: "Report Creation"],


### PR DESCRIPTION
- Add MIT LICENSE file
- Add ROADMAP, SECURITY, IMPLEMENTATION_STATUS, LICENSE to ex_doc extras
- Fix relative path references in user guides (../../ -> direct reference)
- Fix stray code block in json_renderer.ex documentation